### PR TITLE
Stackdriver sidecar

### DIFF
--- a/stable/prometheus-operator/templates/_helpers.tpl
+++ b/stable/prometheus-operator/templates/_helpers.tpl
@@ -39,11 +39,6 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{- printf "%s-alertmanager" (include "prometheus-operator.fullname" .) -}}
 {{- end }}
 
-{{/* Fullnane suffixed with -prom */}}
-{{- define "prometheusServer.fullname" -}}
-{{- printf "%s-prometheus-prom" .Release.Name -}}
-{{- end }}
-
 {{/* Create chart name and version as used by the chart label. */}}
 {{- define "prometheus-operator.chartref" -}}
 {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}

--- a/stable/prometheus-operator/templates/_helpers.tpl
+++ b/stable/prometheus-operator/templates/_helpers.tpl
@@ -39,6 +39,11 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{- printf "%s-alertmanager" (include "prometheus-operator.fullname" .) -}}
 {{- end }}
 
+{{/* Fullnane suffixed with -prom */}}
+{{- define "prometheusServer.fullname" -}}
+{{- printf "%s-prometheus-prom" .Release.Name -}}
+{{- end }}
+
 {{/* Create chart name and version as used by the chart label. */}}
 {{- define "prometheus-operator.chartref" -}}
 {{- replace "+" "_" .Chart.Version | printf "%s-%s" .Chart.Name -}}

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -216,8 +216,28 @@ spec:
     name: {{ template "prometheus-operator.fullname" . }}-prometheus-am-relabel-confg
     key: additional-alert-relabel-configs.yaml
 {{- end }}
-{{- if .Values.prometheus.prometheusSpec.containers }}
+  
+
   containers:
+    # Injects the stackdriver sidecar container for exporting prometheus metrics
+    - name: stackdriver-exporter
+      image: {{ .Values.stackdriverSidecar.image }}
+      imagePullPolicy: Always
+      args: 
+        - --stackdriver.project-id={{ .Values.stackdriverSidecar.gcpProjectId }}
+        - --prometheus.wal-directory=prometheus/wal
+        - --stackdriver.kubernetes.location={{ .Values.stackdriverSidecar.region }}
+        - --stackdriver.kubernetes.cluster-name={{ .Values.stackdriverSidecar.clusterName }}
+        #- \"--stackdriver.generic.location=us-central1\"
+        #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
+      ports:
+        - name: stackdriver-exporter
+          containerPort: 9091
+      volumeMounts:
+        - name: prometheus-monitoring-prometheus-prom-prometheus-db
+          mountPath: /prometheus
+
+{{- if .Values.prometheus.prometheusSpec.containers }}      
 {{ toYaml .Values.prometheus.prometheusSpec.containers | indent 4 }}
 {{- end }}
 {{- if .Values.prometheus.prometheusSpec.priorityClassName }}

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -220,20 +220,20 @@ spec:
   containers:
     # Injects the stackdriver sidecar container for exporting prometheus metrics
     - name: stackdriver-exporter
-      image: {{ .Values.stackdriverSidecar.image }}
+      image: {{ required "A valid image url is required" .Values.stackdriverSidecar.image }}
       imagePullPolicy: Always
       args: 
-        - --stackdriver.project-id={{ .Values.stackdriverSidecar.gcpProjectId }}
+        - --stackdriver.project-id={{ required "A valid GCP project id is required" .Values.stackdriverSidecar.gcpProjectId }}
         - --prometheus.wal-directory=prometheus/wal
-        - --stackdriver.kubernetes.location={{ .Values.stackdriverSidecar.region }}
-        - --stackdriver.kubernetes.cluster-name={{ .Values.stackdriverSidecar.clusterName }}
+        - --stackdriver.kubernetes.location={{ required "A valid gcp region is required." .Values.stackdriverSidecar.region }}
+        - --stackdriver.kubernetes.cluster-name={{ required "A valid GKE cluster name is required" .Values.stackdriverSidecar.clusterName }}
         #- \"--stackdriver.generic.location=us-central1\"
         #- \"--stackdriver.generic.namespace=terra-stackdriver-k8s\"
       ports:
-        - name: stackdriver-exporter
+        - name: stackdriver-exp
           containerPort: 9091
       volumeMounts:
-        - name: {{ template "prometheusServer.fullname" . }}-prometheus-db
+        - name: prometheus-{{ template "prometheus-operator.fullname" . }}-prometheus-db
           mountPath: /prometheus
 
 {{- if .Values.prometheus.prometheusSpec.containers }}      

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -234,7 +234,7 @@ spec:
         - name: stackdriver-exporter
           containerPort: 9091
       volumeMounts:
-        - name: prometheus-monitoring-prometheus-prom-prometheus-db
+        - name: {{ template "prometheus-operator.prometheus.fullname" . }}-prometheus-db
           mountPath: /prometheus
 
 {{- if .Values.prometheus.prometheusSpec.containers }}      

--- a/stable/prometheus-operator/templates/prometheus/prometheus.yaml
+++ b/stable/prometheus-operator/templates/prometheus/prometheus.yaml
@@ -216,7 +216,6 @@ spec:
     name: {{ template "prometheus-operator.fullname" . }}-prometheus-am-relabel-confg
     key: additional-alert-relabel-configs.yaml
 {{- end }}
-  
 
   containers:
     # Injects the stackdriver sidecar container for exporting prometheus metrics
@@ -234,7 +233,7 @@ spec:
         - name: stackdriver-exporter
           containerPort: 9091
       volumeMounts:
-        - name: {{ template "prometheus-operator.prometheus.fullname" . }}-prometheus-db
+        - name: {{ template "prometheusServer.fullname" . }}-prometheus-db
           mountPath: /prometheus
 
 {{- if .Values.prometheus.prometheusSpec.containers }}      

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1903,3 +1903,11 @@ prometheus:
     ## https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#podmetricsendpoint
     ##
     # podMetricsEndpoints: []
+
+# Used for injecting the stackdriver sidecar
+stackdriverSidecar:
+  image: bleh 
+  gcpProjectId: stuff
+  region: boston
+  clusterName: k8s
+

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1904,10 +1904,18 @@ prometheus:
     ##
     # podMetricsEndpoints: []
 
-# Used for injecting the stackdriver sidecar
+# Values for configuring the stackdriver sidecar container for prometheus server.
 stackdriverSidecar:
+  
+  # Supplies the image and version tag of the stackdriver-exporter
   image: bleh 
+
+  # GCP project id for project that hosts stackdriver workspace to export to.
   gcpProjectId: stuff
+
+  # Gcloud region for the cluster being monitored
   region: boston
+
+  # Unique name for the k8s-cluster, must match the name in GKE
   clusterName: k8s
 

--- a/stable/prometheus-operator/values.yaml
+++ b/stable/prometheus-operator/values.yaml
@@ -1906,16 +1906,16 @@ prometheus:
 
 # Values for configuring the stackdriver sidecar container for prometheus server.
 stackdriverSidecar:
-  
+
   # Supplies the image and version tag of the stackdriver-exporter
-  image: bleh 
+  image: "" 
 
   # GCP project id for project that hosts stackdriver workspace to export to.
-  gcpProjectId: stuff
+  gcpProjectId: ""
 
   # Gcloud region for the cluster being monitored
-  region: boston
+  region: ""
 
   # Unique name for the k8s-cluster, must match the name in GKE
-  clusterName: k8s
+  clusterName: ""
 


### PR DESCRIPTION
This is a fork of the stable/prometheus-operator chart intended for use at the Broad Institute. This This chart will install prometheus, grafana, and alert manager monitoring servers on a k8s cluster. 

This version is to be managed by broad-dsp-devops also installs a stackdriver sidecar container on the prometheus server pods for exporting metrics to stackdriver. 

This does require the user to provide 4 override values when installing the chart. These are found in the stackdriver section at the end of values.yaml. The chart requires these overrides to be provided in order to run. If the user does not provide them, the chart will exit at the templating stage with a message about which required stackdriver config values are missing. 

This chart has been tested and successfully installed in the correct configuration to a live GKE cluster.